### PR TITLE
ci(deploy): add digest to docker image to ensure uniqueness

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,6 +38,7 @@ jobs:
           password: ${{ secrets.TIDEV_REGISTRY_PASSWORD }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v5
         with:
           push: true
@@ -47,7 +48,7 @@ jobs:
       - name: Push to dokku
         uses: dokku/github-action@master
         with:
-          deploy_docker_image: ${{ secrets.TIDEV_REGISTRY_URL }}/${{ steps.meta.outputs.tags }}
+          deploy_docker_image: ${{ secrets.TIDEV_REGISTRY_URL }}/${{ steps.meta.outputs.tags }}@${{ steps.build.outputs.digest }}
           git_push_flags: '--force'
           git_remote_url: 'ssh://dokku@tidev.io:22/tidev.io'
           ssh_private_key: ${{ secrets.DO_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
The [dokku docs state](https://dokku.com/docs/deployment/methods/image/) we can use the digest of the image if tags are reused (search for `Triggering a build with the same arguments multiple times will result in Dokku exiting 0 early as there will be no changes detected`)

This is output from the docker build action in the [outputs](https://github.com/docker/build-push-action#outputs) and as the `deploy_docker_image` is just passed to `git:from_image` in the docker [image used by the action ](https://github.com/dokku/ci-docker-image/blob/3456896eda4002c82ee68379e2f017ebd88fcc20/bin/dokku-deploy#L100)I'm fairly sure this should be plumbed together ok.