### PR TITLE
don't upscale images in feature list

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,6 +85,10 @@ p strong {
     @apply w-full p-0 md:px-20;
 }
 
+.blog-content li img {
+    @apply w-[initial] p-0 mt-2 mb-5;
+}
+
 .cla-login {
     @apply absolute flex items-center justify-center bg-black bg-opacity-60 rounded-xl;
     bottom: 13%;


### PR DESCRIPTION
At the moment the images are scaled up to 100% width in the list. This PR will keep the original size and only adds a margin to the top and bottom:



![Bildschirmfoto_20240717_212333](https://github.com/user-attachments/assets/3a322a69-d992-402a-91f0-88f1367010ae)
