### PR TITLE
feat: add 13.0.0.RC changelog

### DIFF
--- a/posts/2025/sdk_13_0_0_rc.md
+++ b/posts/2025/sdk_13_0_0_rc.md
@@ -1,0 +1,30 @@
+---
+title: 'Titanium SDK 13.0.0.RC released'
+date: '2025-09-10'
+category: 'Release'
+author: 'Hans Knöchel'
+teaser: 'Full Support for iOS 26, Xcode 26 and Liquid Glass UI'
+image: https://tidev.io/images/titanium-general.png
+---
+
+![Titanium SDK 13.0.0.RC](/images/titanium-general.png)
+
+Titanium SDK 13.0.0 is a major release of the SDK, providing full support for iOS 26 and Xcode 26.
+
+To view the full list of changes, see the release notes: [Titanium SDK 13.0.0.RC Release Note](https://titaniumsdk.com/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_13.x/Titanium_SDK_13.0.0.RC_Release_Note.html).
+
+## Install
+
+**Follow these steps to get SDK 13.0.0.RC:**
+
+1. Install the CLI with `[sudo] npm i -g titanium alloy`
+2. Run `titanium sdk install 13.0.0.RC`
+3. Set `<sdk-version>13.0.0.RC</sdk-version>` in your `tiapp.xml`
+
+## Report Bugs
+
+If you run into any issues that seem related to the update, please report them on [GitHub](https://github.com/tidev/titanium-sdk/issues).
+
+## How can I support?
+
+If you like our work and want to support, think about a [donation](/donate) or to [contribute](/contribute) with your time and code.

--- a/posts/2025/sdk_13_0_0_rc.md
+++ b/posts/2025/sdk_13_0_0_rc.md
@@ -9,7 +9,8 @@ image: https://tidev.io/images/titanium-general.png
 
 ![Titanium SDK 13.0.0.RC](/images/titanium-general.png)
 
-Titanium SDK 13.0.0 is a major release of the SDK, providing full support for iOS 26 and Xcode 26.
+Titanium SDK 13.0.0 is a major release of the SDK, providing full support for iOS 26 and Xcode 26. It is also compatible with the latest Android 16kb page size requirement by Google and all included first party Android modules support 16kb page size too. Many community modules like the Firebase modules are also already updated.
+If you need help with other modules make sure to join our [Slack group](https://slack.tidev.io/) and ask for support.
 
 To view the full list of changes, see the release notes: [Titanium SDK 13.0.0.RC Release Note](https://titaniumsdk.com/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_13.x/Titanium_SDK_13.0.0.RC_Release_Note.html).
 


### PR DESCRIPTION
This pull request adds a new blog post announcing the release candidate of Titanium SDK 13.0.0. The post provides details about the release, installation instructions, and ways to report bugs or support the project.

Release announcement:

* Added `posts/2025/sdk_13_0_0_rc.md` to announce the Titanium SDK 13.0.0.RC release, including highlights of iOS 26 and Xcode 26 support, installation steps, and links for further information and community support.

@m1ga Feel free to extend the article here with Android details if relevant